### PR TITLE
Dialogue Skip Fix

### DIFF
--- a/Nonstick Summer 2025/Assets/Scripts/Dialogue/DialogueBox.cs
+++ b/Nonstick Summer 2025/Assets/Scripts/Dialogue/DialogueBox.cs
@@ -95,6 +95,8 @@ public class DialogueBox : MonoBehaviour
 
             npcText.text = dialogue[NumberInList].Dialogue;
 
+            Debug.Log($"({NumberInList + 1}/{dialogue.Length}): {dialogue[NumberInList].Dialogue}");
+
         }
         else
         {
@@ -105,9 +107,9 @@ public class DialogueBox : MonoBehaviour
 
             npcText.text = branch.dialogue[NumberInList].Dialogue;
 
-        }
+            Debug.Log($"({NumberInList + 1}/{branch.dialogue.Length}): {branch.dialogue[NumberInList].Dialogue}");
 
-        Debug.Log($"({NumberInList + 1}/{branch.dialogue.Length}): {branch.dialogue[NumberInList].Dialogue}");
+        }
 
         //TODO typewriter text goes here
 

--- a/Nonstick Summer 2025/Assets/Scripts/UI/NPC Encounter/DialogueUIController.cs
+++ b/Nonstick Summer 2025/Assets/Scripts/UI/NPC Encounter/DialogueUIController.cs
@@ -88,7 +88,7 @@ public class DialogueUIController : Singleton<DialogueUIController>
 
         yield return ToggleUIForDialogueProgression(false);
 
-        yield return OpenCombatUI_Coroutine();
+        //yield return OpenCombatUI_Coroutine();
 
         yield return dialogueBox.Initialize(startBranch);
     }


### PR DESCRIPTION
Exactly what it reads on the tin. The function that was commented out was attempting to display the first line of dialogue when DialogueBox Initialize() already takes care of that, thus causing some issues in case I need to explain myself later.