### PR TITLE
Clarifying tooltip text + mom fix

### DIFF
--- a/Nonstick Summer 2025/Assets/Dialogue/Mom/Moment1/Mom_m1_3.asset
+++ b/Nonstick Summer 2025/Assets/Dialogue/Mom/Moment1/Mom_m1_3.asset
@@ -33,7 +33,7 @@ MonoBehaviour:
     PlayerDialogue: Grandma always gets me the best gifts!
     RelationshipCheckRequired: 1
     RelationshipRange: {x: 0, y: 20}
-    BranchingDialogueHigh: {fileID: 11400000, guid: 8e3d5ccbf08c4a843a37ca4236ea51f5, type: 2}
+    BranchingDialogueHigh: {fileID: 11400000, guid: a209ae90deb3d9947b756e4a4d7519c4, type: 2}
     BranchingDialogueNeutral: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     BranchingDialogueLow: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     ChangeInRelationshipStatus: 10
@@ -47,7 +47,7 @@ MonoBehaviour:
     PlayerDialogue: "Grandma doesn\u2019t understand the games I like."
     RelationshipCheckRequired: 1
     RelationshipRange: {x: 0, y: 20}
-    BranchingDialogueHigh: {fileID: 11400000, guid: 8e3d5ccbf08c4a843a37ca4236ea51f5, type: 2}
+    BranchingDialogueHigh: {fileID: 11400000, guid: a209ae90deb3d9947b756e4a4d7519c4, type: 2}
     BranchingDialogueNeutral: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     BranchingDialogueLow: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     ChangeInRelationshipStatus: -5
@@ -71,7 +71,7 @@ MonoBehaviour:
     PlayerDialogue: I want Grandma to make my cake. She makes the best cake.
     RelationshipCheckRequired: 1
     RelationshipRange: {x: 0, y: 20}
-    BranchingDialogueHigh: {fileID: 11400000, guid: 8e3d5ccbf08c4a843a37ca4236ea51f5, type: 2}
+    BranchingDialogueHigh: {fileID: 11400000, guid: a209ae90deb3d9947b756e4a4d7519c4, type: 2}
     BranchingDialogueNeutral: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     BranchingDialogueLow: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     ChangeInRelationshipStatus: 15
@@ -125,11 +125,20 @@ MonoBehaviour:
       Portrait: {fileID: 21300000, guid: 24794c9372059fe4c811fbd57b999120, type: 3}
       AnimatedReaction: {fileID: 1232626074937243997, guid: 4bb1702b19683694abd039f4703039a9, type: 3}
       AudioResponse: Angry
-    CombinedDialogue: []
+    CombinedDialogue:
+    - Dialogue: You should appreciate anything your Grandma gives you. She puts so
+        much thought and care into it.
+      Portrait: {fileID: 21300000, guid: 24794c9372059fe4c811fbd57b999120, type: 3}
+      AnimatedReaction: {fileID: 1232626074937243997, guid: 4bb1702b19683694abd039f4703039a9, type: 3}
+      AudioResponse: Angry
+    - Dialogue: Now, are you ready for your first day of school tomorrow? Big day.
+      Portrait: {fileID: 21300000, guid: 50bb4058fcfd0a848aee129378173f17, type: 3}
+      AnimatedReaction: {fileID: 3538256414719010168, guid: 6b8dd245a4e1d8c48b2809616a868486, type: 3}
+      AudioResponse: Happy
     PlayerDialogue: Do you think Grandma would buy me the really expensive game?
     RelationshipCheckRequired: 1
     RelationshipRange: {x: 0, y: 20}
-    BranchingDialogueHigh: {fileID: 11400000, guid: 8e3d5ccbf08c4a843a37ca4236ea51f5, type: 2}
+    BranchingDialogueHigh: {fileID: 11400000, guid: a209ae90deb3d9947b756e4a4d7519c4, type: 2}
     BranchingDialogueNeutral: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     BranchingDialogueLow: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     ChangeInRelationshipStatus: -10
@@ -144,7 +153,7 @@ MonoBehaviour:
     PlayerDialogue: "She\u2019s just going to make me another blanket, why bother?"
     RelationshipCheckRequired: 1
     RelationshipRange: {x: 0, y: 20}
-    BranchingDialogueHigh: {fileID: 11400000, guid: 8e3d5ccbf08c4a843a37ca4236ea51f5, type: 2}
+    BranchingDialogueHigh: {fileID: 11400000, guid: a209ae90deb3d9947b756e4a4d7519c4, type: 2}
     BranchingDialogueNeutral: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     BranchingDialogueLow: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     ChangeInRelationshipStatus: 10
@@ -158,7 +167,7 @@ MonoBehaviour:
     PlayerDialogue: No, I haven't thought about it... can you help me?
     RelationshipCheckRequired: 1
     RelationshipRange: {x: 0, y: 20}
-    BranchingDialogueHigh: {fileID: 11400000, guid: 8e3d5ccbf08c4a843a37ca4236ea51f5, type: 2}
+    BranchingDialogueHigh: {fileID: 11400000, guid: a209ae90deb3d9947b756e4a4d7519c4, type: 2}
     BranchingDialogueNeutral: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     BranchingDialogueLow: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     ChangeInRelationshipStatus: 10
@@ -172,7 +181,7 @@ MonoBehaviour:
     PlayerDialogue: ...
     RelationshipCheckRequired: 1
     RelationshipRange: {x: 0, y: 20}
-    BranchingDialogueHigh: {fileID: 11400000, guid: 8e3d5ccbf08c4a843a37ca4236ea51f5, type: 2}
+    BranchingDialogueHigh: {fileID: 11400000, guid: a209ae90deb3d9947b756e4a4d7519c4, type: 2}
     BranchingDialogueNeutral: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     BranchingDialogueLow: {fileID: 11400000, guid: 5b121f534c74f534288df6ebe03df590, type: 2}
     ChangeInRelationshipStatus: -5

--- a/Nonstick Summer 2025/Assets/Prefabs/UI/NPC Dialogue/NPC Dialogue Template.prefab
+++ b/Nonstick Summer 2025/Assets/Prefabs/UI/NPC Dialogue/NPC Dialogue Template.prefab
@@ -3957,11 +3957,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tooltipGroup: {fileID: 2188859432546881415}
-  canDiscardText: 'Discards a selected card for [DiscardEnergy]'
-  noCardSelected: 'Discards a selected card for [DiscardEnergy]
+  canDiscardText: Discards a selected card for [DiscardEnergy], will not skip turn.
+  noCardSelected: 'Discards a selected card for [DiscardEnergy], will not skip turn.
 
-    [Gray((No card
-    selected))]'
+    [Gray((No
+    card selected))]'
 --- !u!114 &3229010451872090231 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9070249248627399556, guid: a116fa6baf5133246873b7c421068423, type: 3}


### PR DESCRIPTION
The cleanest solution to clarifying that silence skips a turn and discarding does not is probably adding a skip icon to the silence button itself, but for now I just added a few words to the discard tooltip.

Mom_m1_3 somehow reverted its fixes so redid those as well.